### PR TITLE
补上 host/generic-host 中缺失的顿号

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -235,7 +235,7 @@ Host.CreateDefaultBuilder(args)
 
 ### <a name="environmentname"></a>EnvironmentName
 
-[IHostEnvironment.EnvironmentName](xref:Microsoft.Extensions.Hosting.IHostEnvironment.EnvironmentName*) 属性可以设置为任何值。 框架定义的值包括 `Development``Staging` 和 `Production`。 值不区分大小写。
+[IHostEnvironment.EnvironmentName](xref:Microsoft.Extensions.Hosting.IHostEnvironment.EnvironmentName*) 属性可以设置为任何值。 框架定义的值包括 `Development`、`Staging` 和 `Production`。 值不区分大小写。
 
 键：`environment`  
 类型：`string`  


### PR DESCRIPTION
“框架定义的值包括 `Development``Staging` 和 `Production`。”
该段缺少一个顿号，导致显示不正常