### PR TITLE
‘Protocol Buffers’ does not translate to ‘协议缓冲区’

### DIFF
--- a/aspnetcore/grpc/basics.md
+++ b/aspnetcore/grpc/basics.md
@@ -33,7 +33,7 @@ ms.locfileid: "93061010"
 
 ## <a name="proto-file"></a>proto 文件
 
-gRPC 使用协定优先方法进行 API 开发。 默认情况下，协议缓冲区 (protobuf) 用作接口定义语言 (IDL)。 \*.proto 文件包含：
+gRPC 使用协定优先方法进行 API 开发。 默认情况下，Protocol Buffers 用作接口定义语言 (IDL)。 \*.proto 文件包含：
 
 * gRPC 服务的定义。
 * 在客户端与服务器之间发送的消息。


### PR DESCRIPTION
 ‘协议缓冲区’  is hard to understand

建议的有用信息：
1.请参阅[快速入门本地化样式指南](https://docs.microsoft.com/globalization/localization/styleguides)，了解 Microsoft 风格指南中**最重要的十大规则**。
2.请参阅 [Microsoft 语言门户](https://www.microsoft.com/language)，查看各 Microsoft 产品的**标准化术语翻译**。
